### PR TITLE
fix(storybook): clear unused argtypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ coverage
 
 /cypress/videos/
 /cypress/screenshots/
+storybook-static
 
 # Editor directories and files
 .vscode/*

--- a/src/components/Avatar/LuiAvatar.stories.ts
+++ b/src/components/Avatar/LuiAvatar.stories.ts
@@ -1,14 +1,7 @@
 import LuiAvatar from './LuiAvatar.vue'
 import type { Meta, StoryObj } from '@storybook/vue3'
 
-import {
-  color,
-  size,
-  filter,
-  border,
-  icon,
-  rounded
-} from '../../../.storybook/global-story-argtypes'
+import { color, size, filter, border, rounded } from '../../../.storybook/global-story-argtypes'
 
 const meta: Meta<typeof LuiAvatar> = {
   title: 'LUI/Avatar',
@@ -22,7 +15,6 @@ const meta: Meta<typeof LuiAvatar> = {
     color,
     size,
     filter,
-    icon,
     border,
     rounded,
     text: {

--- a/src/components/Input/LuiInput.stories.ts
+++ b/src/components/Input/LuiInput.stories.ts
@@ -5,7 +5,6 @@ import {
   block,
   rounded,
   size,
-  prepend,
   description,
   state,
   stateIcon
@@ -19,7 +18,6 @@ const meta: Meta<typeof LuiInput> = {
     block,
     rounded,
     size,
-    prepend,
     description,
     state,
     stateIcon,


### PR DESCRIPTION
Remove unused argtypes on LuiInput-prepend and LuiAvatar icon props

# Please check if the PR fulfills these requirements

- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Story have been added / updated (features)
- [ ] Docs have been added / updated (for bug fixes / features)

 **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

 **What is the current behavior?** (You can also link to an open issue here)

 **What is the new behavior (if this is a feature change)?**

 **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

 **Other information**: